### PR TITLE
Add/error handling and logging

### DIFF
--- a/bin/test-db
+++ b/bin/test-db
@@ -7,7 +7,7 @@ from argparse import RawTextHelpFormatter
 
 def start_container(name):
     START_COMMAND = """
-    docker run -p 8000:8000 -d --name {} amazon/dynamodb-local
+    docker run -p 8000:8000 -d --name {} amazon/dynamodb-local -jar DynamoDBLocal.jar -inMemory -sharedDb
     """.format(name)
 
     print("Starting Docker process {} using container: amazon/dynamodb-local".format(name))

--- a/tap_dynamodb/sync.py
+++ b/tap_dynamodb/sync.py
@@ -6,6 +6,22 @@ from tap_dynamodb.sync_strategies.log_based import sync_log_based, has_stream_ag
 
 LOGGER = singer.get_logger()
 
+def clear_state_on_replication_change(stream, state):
+    md_map = metadata.to_map(stream['metadata'])
+    tap_stream_id = stream['tap_stream_id']
+
+    # replication method changed
+    current_replication_method = metadata.get(md_map, (), 'replication-method')
+    last_replication_method = singer.get_bookmark(state, tap_stream_id, 'last_replication_method')
+    if last_replication_method is not None and (current_replication_method != last_replication_method):
+        log_msg = 'Replication method changed from %s to %s, will re-replicate entire collection %s'
+        LOGGER.info(log_msg, last_replication_method, current_replication_method, tap_stream_id)
+        state = singer.reset_stream(state, tap_stream_id)
+
+    state = singer.write_bookmark(state, tap_stream_id, 'last_replication_method', current_replication_method)
+
+    return state
+
 def sync_stream(config, state, stream):
     table_name = stream['tap_stream_id']
 
@@ -13,9 +29,8 @@ def sync_stream(config, state, stream):
     replication_method = metadata.get(md_map, (), 'replication-method')
     key_properties = metadata.get(md_map, (), 'table-key-properties')
 
-    # TODO Clear state on replication method change?
-
     # write state message with currently_syncing bookmark
+    state = clear_state_on_replication_change(stream, state)
     state = singer.set_currently_syncing(state, table_name)
     singer.write_state(state)
 

--- a/tap_dynamodb/sync.py
+++ b/tap_dynamodb/sync.py
@@ -14,7 +14,7 @@ def clear_state_on_replication_change(stream, state):
     current_replication_method = metadata.get(md_map, (), 'replication-method')
     last_replication_method = singer.get_bookmark(state, tap_stream_id, 'last_replication_method')
     if last_replication_method is not None and (current_replication_method != last_replication_method):
-        log_msg = 'Replication method changed from %s to %s, will re-replicate entire collection %s'
+        log_msg = 'Replication method changed from %s to %s, will re-replicate entire table %s'
         LOGGER.info(log_msg, last_replication_method, current_replication_method, tap_stream_id)
         state = singer.reset_stream(state, tap_stream_id)
 

--- a/tap_dynamodb/sync_strategies/log_based.py
+++ b/tap_dynamodb/sync_strategies/log_based.py
@@ -121,14 +121,14 @@ def sync_log_based(config, state, stream):
             else:
                 record_message = deserializer.deserialize_item(record['dynamodb'].get('NewImage'))
                 if record_message is None:
-                    LOGGER.fatal('Stream is not "NEW_IMAGE" or "NEW_AND_OLD_IMAGES". You must set the stream to either of these for log based replication to work.')
-                    raise Exception("Find a better exception class") # TODO <-
+                    LOGGER.fatal('Dynamo stream view type must be either "NEW_IMAGE" "NEW_AND_OLD_IMAGES"')
+                    raise RuntimeError('Dynamo stream view type must be either "NEW_IMAGE" "NEW_AND_OLD_IMAGES"')
                 if projection is not None:
                     try:
                         record_message = deserializer.apply_projection(record_message, projection)
                     except:
                         LOGGER.fatal("Projection failed to apply: %s", metadata.get(md_map, (), 'tap-mongodb.projection'))
-                        raise Exception("Find a better exception class") # TODO <-
+                        raise RuntimeError('Projection failed to apply: {}'.format(metadata.get(md_map, (), 'tap-mongodb.projection')))
 
             singer.write_record(table_name, record_message)
             rows_saved += 1


### PR DESCRIPTION
# Description of change
Added error handling around log based projections and if the stream view type is neither "NEW_IMAGE" or "NEW_AND_OLD_IMAGES".

Also clears state on replication method changing.

# Manual QA steps
 - Ran the tap multiple times, swapping the replication method
 
# Risks
 - Low
 
# Rollback steps
 - revert this branch
