### PR TITLE
add region_name when retrieving client

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-dynamodb",
-    version="0.0.0",
+    version="0.1.0",
     description="Singer.io tap for extracting data",
     author="Stitch",
     url="http://singer.io",

--- a/tap_dynamodb/__init__.py
+++ b/tap_dynamodb/__init__.py
@@ -12,7 +12,7 @@ from tap_dynamodb.sync import sync_stream
 
 LOGGER = singer.get_logger()
 
-REQUIRED_CONFIG_KEYS = ["account_id", "external_id", "role_name"]
+REQUIRED_CONFIG_KEYS = ["account_id", "external_id", "role_name", "region_name"]
 
 def do_discover(config):
     LOGGER.info("Starting discover")

--- a/tap_dynamodb/dynamodb.py
+++ b/tap_dynamodb/dynamodb.py
@@ -68,7 +68,7 @@ def get_client(config):
     if config.get('use_local_dynamo'):
         return boto3.client('dynamodb',
                             endpoint_url='http://localhost:8000',
-                            region_name =config.get('region_name', 'us-east-1'))
+                            region_name=config.get('region_name', 'us-east-1'))
     return boto3.client('dynamodb', config.get('region_name', 'us-east-1'))
 
 def get_stream_client(config):

--- a/tap_dynamodb/dynamodb.py
+++ b/tap_dynamodb/dynamodb.py
@@ -66,10 +66,15 @@ def setup_aws_client(config):
 
 def get_client(config):
     if config.get('use_local_dynamo'):
-        return boto3.client('dynamodb', endpoint_url='http://localhost:8000', region_name='us-east-1')
-    return boto3.client('dynamodb')
+        return boto3.client('dynamodb',
+                            endpoint_url='http://localhost:8000',
+                            region_name =config.get('region_name', 'us-east-1'))
+    return boto3.client('dynamodb', config.get('region_name', 'us-east-1'))
 
 def get_stream_client(config):
     if config.get('use_local_dynamo'):
-        return boto3.client('dynamodbstreams', endpoint_url='http://localhost:8000', region_name='us-east-1')
-    return boto3.client('dynamodbstreams')
+        return boto3.client('dynamodbstreams',
+                            endpoint_url='http://localhost:8000',
+                            region_name=config.get('region_name', 'us-east-1'))
+    return boto3.client('dynamodbstreams',
+                        region_name=config.get('region_name', 'us-east-1'))

--- a/tap_dynamodb/dynamodb.py
+++ b/tap_dynamodb/dynamodb.py
@@ -68,13 +68,13 @@ def get_client(config):
     if config.get('use_local_dynamo'):
         return boto3.client('dynamodb',
                             endpoint_url='http://localhost:8000',
-                            region_name=config.get('region_name', 'us-east-1'))
-    return boto3.client('dynamodb', config.get('region_name', 'us-east-1'))
+                            region_name=config['region_name'])
+    return boto3.client('dynamodb', config['region_name'])
 
 def get_stream_client(config):
     if config.get('use_local_dynamo'):
         return boto3.client('dynamodbstreams',
                             endpoint_url='http://localhost:8000',
-                            region_name=config.get('region_name', 'us-east-1'))
+                            region_name=config['region_name'])
     return boto3.client('dynamodbstreams',
-                        region_name=config.get('region_name', 'us-east-1'))
+                        region_name=config['region_name'])


### PR DESCRIPTION
# Description of change
The tap needs to specify the aws region name when getting a boto3 client.  This PR adds functionality to use a `region_name` config property

# Manual QA steps
 - Cloned connection that was failing to find any streams without a specified `region_name`.  Adding a `region_name` fixed this bug.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
