### PR TITLE
Fix/missing key in log based projection

### DIFF
--- a/tap_dynamodb/deserialize.py
+++ b/tap_dynamodb/deserialize.py
@@ -49,7 +49,7 @@ class Deserializer(TypeDeserializer):
                     output[breadcrumb_key] = [record[breadcrumb_key][index]]
 
             else:
-                output[breadcrumb[0]] = record.get(breadcrumb[0], {})
+                output[breadcrumb[0]] = record.get(breadcrumb[0])
         else:
             if '[' in breadcrumb[0]:
                 breadcrumb_key = breadcrumb[0].split('[')[0]

--- a/tap_dynamodb/deserialize.py
+++ b/tap_dynamodb/deserialize.py
@@ -49,7 +49,7 @@ class Deserializer(TypeDeserializer):
                     output[breadcrumb_key] = [record[breadcrumb_key][index]]
 
             else:
-                output[breadcrumb[0]] = record[breadcrumb[0]]
+                output[breadcrumb[0]] = record.get(breadcrumb[0], {})
         else:
             if '[' in breadcrumb[0]:
                 breadcrumb_key = breadcrumb[0].split('[')[0]

--- a/tap_dynamodb/sync_strategies/log_based.py
+++ b/tap_dynamodb/sync_strategies/log_based.py
@@ -152,7 +152,7 @@ def sync_log_based(config, state, stream):
                 seq_number_bookmarks.pop(shard['ShardId'])
                 state = singer.write_bookmark(state, table_name, 'shard_seq_numbers', seq_number_bookmarks)
 
-        singer.write_state(state)
+    singer.write_state(state)
 
     return rows_saved
 

--- a/tap_dynamodb/sync_strategies/log_based.py
+++ b/tap_dynamodb/sync_strategies/log_based.py
@@ -152,7 +152,7 @@ def sync_log_based(config, state, stream):
                 seq_number_bookmarks.pop(shard['ShardId'])
                 state = singer.write_bookmark(state, table_name, 'shard_seq_numbers', seq_number_bookmarks)
 
-    singer.write_state(state)
+        singer.write_state(state)
 
     return rows_saved
 


### PR DESCRIPTION
# Description of change
https://stitchdata.atlassian.net/browse/SUP-1192
If a key listed in a projection expression is absent from the retrieved record then set the value in `RECORD` message to None instead of throwing an exception.

# Manual QA steps
 - Ran the tap on a connection with missing record keys
 
# Risks
 - None. `get()` is safer than array accessors so this should not be possible for this to introduce any errors.
 
# Rollback steps
 - revert this branch
