### PR TITLE
Fix/make log based bookmarks work

### DIFF
--- a/tap_dynamodb/sync_strategies/log_based.py
+++ b/tap_dynamodb/sync_strategies/log_based.py
@@ -119,6 +119,9 @@ def sync_shard(shard, seq_number_bookmarks, streams_client, stream_arn, projecti
         seq_number_bookmarks[shard['ShardId']] = record['dynamodb']['SequenceNumber']
         state = singer.write_bookmark(state, table_name, 'shard_seq_numbers', seq_number_bookmarks)
 
+    if rows_synced > 0:
+        singer.write_state(state)
+
     return rows_synced
 
 
@@ -181,10 +184,6 @@ def sync_log_based(config, state, stream):
                 state = singer.write_bookmark(state, table_name, 'finished_shards', finished_shard_bookmarks)
                 state = singer.write_bookmark(state, table_name, 'shard_seq_numbers', seq_number_bookmarks)
                 singer.write_state(state)
-
-        if rows_synced % WRITE_STATE_PERIOD == 0:
-            singer.write_state(state)
-
 
     for shard in finished_shard_bookmarks:
         if shard not in found_shards:

--- a/tap_dynamodb/sync_strategies/log_based.py
+++ b/tap_dynamodb/sync_strategies/log_based.py
@@ -119,9 +119,6 @@ def sync_shard(shard, seq_number_bookmarks, streams_client, stream_arn, projecti
         seq_number_bookmarks[shard['ShardId']] = record['dynamodb']['SequenceNumber']
         state = singer.write_bookmark(state, table_name, 'shard_seq_numbers', seq_number_bookmarks)
 
-        if rows_synced % WRITE_STATE_PERIOD == 0:
-            singer.write_state(state)
-
     return rows_synced
 
 
@@ -184,6 +181,10 @@ def sync_log_based(config, state, stream):
                 state = singer.write_bookmark(state, table_name, 'finished_shards', finished_shard_bookmarks)
                 state = singer.write_bookmark(state, table_name, 'shard_seq_numbers', seq_number_bookmarks)
                 singer.write_state(state)
+
+        if rows_synced % WRITE_STATE_PERIOD == 0:
+            singer.write_state(state)
+
 
     for shard in finished_shard_bookmarks:
         if shard not in found_shards:

--- a/tap_dynamodb/sync_strategies/log_based.py
+++ b/tap_dynamodb/sync_strategies/log_based.py
@@ -84,7 +84,7 @@ def get_latest_seq_numbers(config, stream):
     return sequence_number_bookmarks
 
 
-def sync_shard(shard, seq_number_bookmarks, streams_client, stream_arn, projection, md_map, deserializer, table_name, stream_version, state):
+def sync_shard(shard, seq_number_bookmarks, streams_client, stream_arn, projection, deserializer, table_name, stream_version, state):
     seq_number = seq_number_bookmarks.get(shard['ShardId'])
     if seq_number:
         iterator_type = 'AFTER_SEQUENCE_NUMBER'
@@ -106,8 +106,8 @@ def sync_shard(shard, seq_number_bookmarks, streams_client, stream_arn, projecti
                 try:
                     record_message = deserializer.apply_projection(record_message, projection)
                 except:
-                    LOGGER.fatal("Projection failed to apply: %s", metadata.get(md_map, (), 'tap-mongodb.projection'))
-                    raise RuntimeError('Projection failed to apply: {}'.format(metadata.get(md_map, (), 'tap-mongodb.projection')))
+                    LOGGER.fatal("Projection failed to apply: %s", projection)
+                    raise RuntimeError('Projection failed to apply: {}'.format(projection))
 
         record_message = singer.RecordMessage(stream=table_name,
                                             record=record_message,
@@ -169,7 +169,7 @@ def sync_log_based(config, state, stream):
         # Only sync shards which we have not fully synced already
         if shard['ShardId'] not in finished_shard_bookmarks:
             rows_synced += sync_shard(shard, seq_number_bookmarks,
-                                      streams_client, stream_arn, projection, md_map, deserializer,
+                                      streams_client, stream_arn, projection, deserializer,
                                       table_name, stream_version, state)
 
         # If the shard we just finished syncing is closed (i.e. has an

--- a/tap_dynamodb/sync_strategies/log_based.py
+++ b/tap_dynamodb/sync_strategies/log_based.py
@@ -213,7 +213,7 @@ def has_stream_aged_out(config, state, stream):
         # are returned to us by get_shards then we have not missed any
         # records
         closed_shards =  (x['ShardId'] for x in get_shards(streams_client, stream_arn) if x['SequenceNumberRange'].get('EndingSequenceNumber', False))
-        finished_shard_bookmarks = singer.get_bookmark(state, table_name, 'finished_shards')
+        finished_shard_bookmarks = singer.get_bookmark(state, stream['tap_stream_id'], 'finished_shards')
         for shard in closed_shards:
             if shard in finished_shard_bookmarks:
                 return False

--- a/tap_dynamodb/sync_strategies/log_based.py
+++ b/tap_dynamodb/sync_strategies/log_based.py
@@ -83,6 +83,48 @@ def get_latest_seq_numbers(config, stream):
 
     return sequence_number_bookmarks
 
+
+def sync_shard(shard, seq_number_bookmarks, streams_client, stream_arn, projection, md_map, deserializer, table_name, stream_version, state):
+    seq_number = seq_number_bookmarks.get(shard['ShardId'])
+    if seq_number:
+        iterator_type = 'AFTER_SEQUENCE_NUMBER'
+    else:
+        iterator_type = 'TRIM_HORIZON'
+
+    rows_synced = 0
+
+    for record in get_shard_records(streams_client, stream_arn, shard, iterator_type, seq_number):
+        if record['eventName'] == 'REMOVE':
+            record_message = deserializer.deserialize_item(record['dynamodb']['Keys'])
+            record_message[SDC_DELETED_AT] = singer.utils.strftime(record['dynamodb']['ApproximateCreationDateTime'])
+        else:
+            record_message = deserializer.deserialize_item(record['dynamodb'].get('NewImage'))
+            if record_message is None:
+                LOGGER.fatal('Dynamo stream view type must be either "NEW_IMAGE" "NEW_AND_OLD_IMAGES"')
+                raise RuntimeError('Dynamo stream view type must be either "NEW_IMAGE" "NEW_AND_OLD_IMAGES"')
+            if projection is not None:
+                try:
+                    record_message = deserializer.apply_projection(record_message, projection)
+                except:
+                    LOGGER.fatal("Projection failed to apply: %s", metadata.get(md_map, (), 'tap-mongodb.projection'))
+                    raise RuntimeError('Projection failed to apply: {}'.format(metadata.get(md_map, (), 'tap-mongodb.projection')))
+
+        record_message = singer.RecordMessage(stream=table_name,
+                                            record=record_message,
+                                            version=stream_version)
+        singer.write_message(record_message)
+
+        rows_synced += 1
+
+        seq_number_bookmarks[shard['ShardId']] = record['dynamodb']['SequenceNumber']
+        state = singer.write_bookmark(state, table_name, 'shard_seq_numbers', seq_number_bookmarks)
+
+        if rows_synced % WRITE_STATE_PERIOD == 0:
+            singer.write_state(state)
+
+    return rows_synced
+
+
 def sync_log_based(config, state, stream):
     table_name = stream['tap_stream_id']
 
@@ -100,65 +142,65 @@ def sync_log_based(config, state, stream):
 
     table = client.describe_table(TableName=table_name)['Table']
     stream_arn = table['LatestStreamArn']
+
+    # Stores a dictionary of shardId : sequence_number for a shard. Should
+    # only store sequence numbers for open shards, as closed shards should
+    # be put into finished_shard_bookmarks
     seq_number_bookmarks = singer.get_bookmark(state, table_name, 'shard_seq_numbers')
+
+    # Store the list of closed shards which we have fully synced. These
+    # are removed after performing a sync and not seeing the shardId
+    # returned by get_shards() because at that point the shard has been
+    # killed by DynamoDB and will not be returned anymore
+    finished_shard_bookmarks = singer.get_bookmark(state, table_name, 'finished_shards')
+    if finished_shard_bookmarks is None:
+        finished_shard_bookmarks = []
+
+    # The list of shardIds we found this sync. Is used to determine which
+    # finished_shard_bookmarks to kill
+    found_shards = []
 
     deserializer = deserialize.Deserializer()
 
-    rows_saved = 0
+    rows_synced = 0
 
     for shard in get_shards(streams_client, stream_arn):
-        # check for bookmark
-        seq_number = seq_number_bookmarks.get(shard['ShardId'])
-        if seq_number:
-            iterator_type = 'AFTER_SEQUENCE_NUMBER'
-        else:
-            iterator_type = 'TRIM_HORIZON'
-
-        for record in get_shard_records(streams_client, stream_arn, shard, iterator_type, seq_number):
-            if record['eventName'] == 'REMOVE':
-                record_message = deserializer.deserialize_item(record['dynamodb']['Keys'])
-                record_message[SDC_DELETED_AT] = singer.utils.strftime(record['dynamodb']['ApproximateCreationDateTime'])
-            else:
-                record_message = deserializer.deserialize_item(record['dynamodb'].get('NewImage'))
-                if record_message is None:
-                    LOGGER.fatal('Dynamo stream view type must be either "NEW_IMAGE" "NEW_AND_OLD_IMAGES"')
-                    raise RuntimeError('Dynamo stream view type must be either "NEW_IMAGE" "NEW_AND_OLD_IMAGES"')
-                if projection is not None:
-                    try:
-                        record_message = deserializer.apply_projection(record_message, projection)
-                    except:
-                        LOGGER.fatal("Projection failed to apply: %s", metadata.get(md_map, (), 'tap-mongodb.projection'))
-                        raise RuntimeError('Projection failed to apply: {}'.format(metadata.get(md_map, (), 'tap-mongodb.projection')))
-
-            record_message = singer.RecordMessage(stream=table_name,
-                                                  record=record_message,
-                                                  version=stream_version)
-            singer.write_message(record_message)
-
-            rows_saved += 1
-
-            seq_number_bookmarks[shard['ShardId']] = record['dynamodb']['SequenceNumber']
-            state = singer.write_bookmark(state, table_name, 'shard_seq_numbers', seq_number_bookmarks)
-
-            if rows_saved % WRITE_STATE_PERIOD == 0:
-                singer.write_state(state)
+        found_shards.append(shard['ShardId'])
+        # Only sync shards which we have not fully synced already
+        if shard['ShardId'] not in finished_shard_bookmarks:
+            rows_synced += sync_shard(shard, seq_number_bookmarks,
+                                      streams_client, stream_arn, projection, md_map, deserializer,
+                                      table_name, stream_version, state)
 
         # If the shard we just finished syncing is closed (i.e. has an
-        # EndingSequenceNumber), pop it off
+        # EndingSequenceNumber), remove it from the seq_number_bookmark
+        # and put it into the finished_shards bookmark
         if shard['SequenceNumberRange'].get('EndingSequenceNumber'):
             # Must check if the bookmark exists because if a shard has 0
             # records we will never set a bookmark for the shard
             if seq_number_bookmarks.get(shard['ShardId']):
                 seq_number_bookmarks.pop(shard['ShardId'])
+                finished_shard_bookmarks.append(shard['ShardId'])
+                state = singer.write_bookmark(state, table_name, 'finished_shards', finished_shard_bookmarks)
                 state = singer.write_bookmark(state, table_name, 'shard_seq_numbers', seq_number_bookmarks)
+                singer.write_state(state)
 
-        singer.write_state(state)
+    for shard in finished_shard_bookmarks:
+        if shard not in found_shards:
+            # Remove this shard because its no longer appearing when we query for get_shards
+            finished_shard_bookmarks.remove(shard)
+            state = singer.write_bookmark(state, table_name, 'finished_shards', finished_shard_bookmarks)
 
-    return rows_saved
+    singer.write_state(state)
+
+    return rows_synced
 
 def has_stream_aged_out(config, state, stream):
     # TODO Check if the beginning sequence number can move. If it cannot this > check is useless
     seq_number_bookmarks = singer.get_bookmark(state, stream['tap_stream_id'], 'shard_seq_numbers')
+
+    # TODO I think this is backwards? If we don't have any
+    # seq_number_bookmarks then where do we begin with logs?
     if seq_number_bookmarks is None:
         return False
 


### PR DESCRIPTION
# Description of change
https://stitchdata.atlassian.net/browse/SRCE-2291
There was a problem with log based bookmarks that caused the tap to sync shards multiple times. The only bookmark we used was the `shard_seq_numbers` which kept track of the last sequence number we synced for a given shard. However the bookmark for a shard was popped off when we finished syncing the shard and the shard was closed (ie would no longer receive any new records). But this meant that the tap had no knowledge of previously synced and closed shards, which meant that on each extraction the tap would sync the closed shards again resulting in unnecessary record messages.

This PR adds a new bookmark which keeps track of the closed shards which we have fully synced. When we remove the `shard_seq_numbers` bookmark we add the shard Id to the new `finished_shards` bookmark (which is a list). We then use this `finished_shards` bookmark to allow us to skip over already synced and closed shard in the main sync loop.

To prevent this list from growing indefinitely we keep a list of all shard Ids we've seen during the sync and after syncing we prune any shard Ids that we did not see as that meant the shard was deleted and would no longer be sent to us by DynamoDB on subsequent syncs.

I also refactored the shard syncing functionality to make `sync_log_based` easier to read as it was getting overly large.

# Manual QA steps
 - Ran the tap with special testing code in place to mimic a closed shard because I do not know of a way to force DynamoDB to close a shard.
- Automated tests still work.
 
# Risks
 - Low. The tap will gracefully handle the bookmark not being present so it should not break any existing connections
 
# Rollback steps
 - revert this branch
