### PR TITLE
Paginate tables on discovery

### DIFF
--- a/tap_dynamodb/discover.py
+++ b/tap_dynamodb/discover.py
@@ -35,11 +35,16 @@ def discover_streams(config):
         LOGGER.critical("Authorization to AWS failed. Please ensure the role and policy are configured correctly on your AWS account.")
         raise Exception("Authorization to AWS failed. Please ensure the role and policy are configured correctly on your AWS account.")
 
-    lastEvaluatedTableName = response.get('LastEvaluatedTableName', None)
     table_list = response.get('TableNames')
-    while lastEvaluatedTableName is not None:
-        response = client.list_tables()
-        lastEvaluatedTableName = response.get('LastEvaluatedTableName', None)
+    for table_name in table_list:
+        LOGGER.info('Discovered table %s', table_name)
+
+    while response.get('LastEvaluatedTableName') is not None:
+        response = client.list_tables(ExclusiveStartTableName=response.get('LastEvaluatedTableName'))
+
+        for table_name in response.get('TableNames'):
+            LOGGER.info('Discovered table %s', table_name)
+
         table_list += response.get('TableNames')
 
     streams = [discover_table_schema(client, table) for table in table_list]

--- a/tap_dynamodb/discover.py
+++ b/tap_dynamodb/discover.py
@@ -39,14 +39,9 @@ def discover_streams(config):
         raise Exception("Authorization to AWS failed. Please ensure the role and policy are configured correctly on your AWS account.")
 
     table_list = response.get('TableNames')
-    for table_name in table_list:
-        LOGGER.info('Discovered table %s', table_name)
 
     while response.get('LastEvaluatedTableName') is not None:
         response = client.list_tables(ExclusiveStartTableName=response.get('LastEvaluatedTableName'))
-
-        for table_name in response.get('TableNames'):
-            LOGGER.info('Discovered table %s', table_name)
 
         table_list += response.get('TableNames')
 

--- a/tap_dynamodb/discover.py
+++ b/tap_dynamodb/discover.py
@@ -42,7 +42,6 @@ def discover_streams(config):
 
     while response.get('LastEvaluatedTableName') is not None:
         response = client.list_tables(ExclusiveStartTableName=response.get('LastEvaluatedTableName'))
-
         table_list += response.get('TableNames')
 
     streams = [x for x in


### PR DESCRIPTION
# Description of change
The tap was not properly paginating over tables on discovery. Now it will paginate correctly.

Additionally incorporating changes from #10 to allow the tap to not require access to every table.

# Manual QA steps
 - Ran against a dynamodb database with more than 1 page of tables and it succeeded.
 
# Risks
 - Low. Ran discovery against a database with many tables and it worked well.
 
# Rollback steps
 - revert this branch
