### PR TITLE
Use table_name if different from tap_stream_id

### DIFF
--- a/tap_dynamodb/sync.py
+++ b/tap_dynamodb/sync.py
@@ -22,7 +22,7 @@ def clear_state_on_replication_change(stream, state):
     return state
 
 def sync_stream(config, state, stream):
-    table_name = stream['tap_stream_id']
+    table_name = stream.get('table_name', stream['tap_stream_id'])
 
     md_map = metadata.to_map(stream['metadata'])
     replication_method = metadata.get(md_map, (), 'replication-method')


### PR DESCRIPTION
# Description of change

According to the Singer spec, I believe the tap is supposed to use the stream's `table_name` field, if provided, to specify the source table. This is important so that a use who is customizing the stream catalog can redirect a given table to another downstream stream or table name.

_(In our case, this is necessary due to special characters ('-') in the DynamoDB table name, which we do not want to have replicated to the downstream database's table name.)_

# Manual QA steps

 - [ ] None yet. (TODO)
 
# Risks

 - Minimal, unless others have overridden `table_name` without expecting this behavior.
 
# Rollback steps

 - revert this branch
