### PR TITLE
Added None check in deserialize.py

### DIFF
--- a/tap_dynamodb/deserialize.py
+++ b/tap_dynamodb/deserialize.py
@@ -11,7 +11,13 @@ class Deserializer(TypeDeserializer):
     '''
 
     def deserialize_item(self, item):
-        return self.deserialize({'M': item})
+        '''
+        Deserializes dictionary objects otherwise checks if None and 
+        deserializes to appropriate Pythonic value - None.
+        '''
+        if item is not None:
+            return self.deserialize({'M': item})
+        return self.deserialize({'NULL': True})
 
     def _deserialize_b(self, value):
         '''


### PR DESCRIPTION
Avoids the scenario where NewImage is not found on the stream record resulting in an attempt to deserialize the items on NoneType ie. `{'M': None}` now calls as `{'Null':True}` instead.

# Description of change
See issue #30 for details on fix

# Manual QA steps
 - Configure DynamoDB Stream with StreamViewType : "KEYS_ONLY". Configure LOG_BASED Stitch extraction of DynamoDB stream. 
 - When the extraction fails the following error message should be seen: `Dynamo stream view type must be either "NEW_IMAGE" "NEW_AND_OLD_IMAGES` NOT `Extraction failed for ‘NoneType’ object has no attribute ‘items'`
 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
