### PR TITLE
Widen Deserialize Decimal precision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.1.2
+  * Fix issue where decimals can throw a Rounded signal if they are too wide [#33](https://github.com/singer-io/tap-dynamodb/pull/33)
+
 ## 1.1.1
   * Add more error checking to ensure a projection provided is also not empty [#26](https://github.com/singer-io/tap-dynamodb/pull/26)
 

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 .DEFAULT_GOAL := lint
 
 lint-tests:
-	pylint tests -d broad-except,chained-comparison,empty-docstring,fixme,invalid-name,line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-else-raise,no-else-return,too-few-public-methods,too-many-arguments,too-many-branches,too-many-lines,too-many-locals,ungrouped-imports,wrong-spelling-in-comment,wrong-spelling-in-docstring,duplicate-code,no-name-in-module,import-error
+	pylint tests -d broad-except,chained-comparison,empty-docstring,fixme,invalid-name,line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-else-raise,no-else-return,too-few-public-methods,too-many-arguments,too-many-branches,too-many-lines,too-many-locals,ungrouped-imports,wrong-spelling-in-comment,wrong-spelling-in-docstring,duplicate-code,no-name-in-module,import-error,consider-using-f-string
 
 lint-code:
-	pylint tap_dynamodb -d broad-except,chained-comparison,empty-docstring,fixme,invalid-name,line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-else-raise,no-else-return,too-few-public-methods,too-many-arguments,too-many-branches,too-many-lines,too-many-locals,ungrouped-imports,wrong-spelling-in-comment,wrong-spelling-in-docstring,raise-missing-from
+	pylint tap_dynamodb -d broad-except,chained-comparison,empty-docstring,fixme,invalid-name,line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-else-raise,no-else-return,too-few-public-methods,too-many-arguments,too-many-branches,too-many-lines,too-many-locals,ungrouped-imports,wrong-spelling-in-comment,wrong-spelling-in-docstring,raise-missing-from,consider-using-f-string
 
 lint: lint-code lint-tests

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-dynamodb",
-    version="1.1.1",
+    version="1.1.2",
     description="Singer.io tap for extracting data",
     author="Stitch",
     url="http://singer.io",

--- a/tap_dynamodb/sync_strategies/log_based.py
+++ b/tap_dynamodb/sync_strategies/log_based.py
@@ -139,7 +139,7 @@ def sync(config, state, stream):
     # fully synced
     seq_number_bookmarks = singer.get_bookmark(state, table_name, 'shard_seq_numbers')
     if not seq_number_bookmarks:
-        seq_number_bookmarks = dict()
+        seq_number_bookmarks = {}
 
     # Get the list of closed shards which we have fully synced. These
     # are removed after performing a sync and not seeing the shardId
@@ -147,7 +147,7 @@ def sync(config, state, stream):
     # killed by DynamoDB and will not be returned anymore
     finished_shard_bookmarks = singer.get_bookmark(state, table_name, 'finished_shards')
     if not finished_shard_bookmarks:
-        finished_shard_bookmarks = list()
+        finished_shard_bookmarks = []
 
     # The list of shardIds we found this sync. Is used to determine which
     # finished_shard_bookmarks to kill

--- a/tests/base.py
+++ b/tests/base.py
@@ -7,9 +7,9 @@ from boto3.dynamodb.types import TypeSerializer, TypeDeserializer
 
 import singer
 
-import tap_tester.connections as connections
-import tap_tester.menagerie   as menagerie
-import tap_tester.runner      as runner
+from tap_tester import connections
+from tap_tester import menagerie
+from tap_tester import runner
 
 ALL_TABLE_NAMES_TO_CLEAR = frozenset({
     'simple_table_1',

--- a/tests/test_dynamodb_full_table_interruptible_sync.py
+++ b/tests/test_dynamodb_full_table_interruptible_sync.py
@@ -4,9 +4,9 @@ import singer
 from boto3.dynamodb.types import TypeSerializer
 
 from tap_tester.scenario import (SCENARIOS)
-import tap_tester.connections as connections
-import tap_tester.menagerie as menagerie
-import tap_tester.runner as runner
+from tap_tester import connections
+from tap_tester import menagerie
+from tap_tester import runner
 
 from base import TestDynamoDBBase
 

--- a/tests/test_dynamodb_full_table_sync.py
+++ b/tests/test_dynamodb_full_table_sync.py
@@ -5,9 +5,9 @@ import singer
 from boto3.dynamodb.types import TypeSerializer
 
 from tap_tester.scenario import (SCENARIOS)
-import tap_tester.connections as connections
-import tap_tester.menagerie   as menagerie
-import tap_tester.runner      as runner
+from tap_tester import connections
+from tap_tester import menagerie
+from tap_tester import runner
 
 from base import TestDynamoDBBase
 

--- a/tests/test_dynamodb_log_based.py
+++ b/tests/test_dynamodb_log_based.py
@@ -3,9 +3,9 @@ import singer
 from boto3.dynamodb.types import TypeSerializer
 
 from tap_tester.scenario import (SCENARIOS)
-import tap_tester.connections as connections
-import tap_tester.menagerie   as menagerie
-import tap_tester.runner      as runner
+from tap_tester import connections
+from tap_tester import menagerie
+from tap_tester import runner
 
 from base import TestDynamoDBBase
 

--- a/tests/test_dynamodb_log_based_interruptible.py
+++ b/tests/test_dynamodb_log_based_interruptible.py
@@ -3,9 +3,9 @@ import singer
 from boto3.dynamodb.types import TypeSerializer
 
 from tap_tester.scenario import (SCENARIOS)
-import tap_tester.connections as connections
-import tap_tester.menagerie   as menagerie
-import tap_tester.runner      as runner
+from tap_tester import connections
+from tap_tester import menagerie
+from tap_tester import runner
 
 from base import TestDynamoDBBase
 

--- a/tests/test_dynamodb_log_based_projections.py
+++ b/tests/test_dynamodb_log_based_projections.py
@@ -4,9 +4,9 @@ import singer
 from boto3.dynamodb.types import TypeSerializer
 
 from tap_tester.scenario import (SCENARIOS)
-import tap_tester.connections as connections
-import tap_tester.menagerie as menagerie
-import tap_tester.runner as runner
+from tap_tester import connections
+from tap_tester import menagerie
+from tap_tester import runner
 
 from base import TestDynamoDBBase
 

--- a/tests/test_dynamodb_projections.py
+++ b/tests/test_dynamodb_projections.py
@@ -4,9 +4,9 @@ import singer
 from boto3.dynamodb.types import TypeSerializer
 
 from tap_tester.scenario import (SCENARIOS)
-import tap_tester.connections as connections
-import tap_tester.menagerie   as menagerie
-import tap_tester.runner      as runner
+from tap_tester import connections
+from tap_tester import menagerie
+from tap_tester import runner
 from base import TestDynamoDBBase
 
 LOGGER = singer.get_logger()


### PR DESCRIPTION
# Description of change
The tap errors in the case that a value exceeds 38 precision. In most warehouses, this is an error, but that's not for the tap to decide. However, knowing when rounding occurs during extraction is good, so trapping the signal from the Python `decimal` module is acceptable.

This PR expands the precision to match the max width of a `singer.decimal` (just to be consistent, even though this tap does not use more dynamic schemas).

# Manual QA steps
 - Manually reproduced a case where a value would throw a Rounding error, confirmed it's fixed by this changed.
 
# Risks
 - Low, this should just expand the range of values that the tap can emit and give developers more control over the behavior of it.
 
# Rollback steps
 - revert this branch and release new patch version
