### PR TITLE
Tdl 16328 implement request timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
           name: 'pylint'
           command: |
             source /usr/local/share/virtualenvs/tap-dynamodb/bin/activate
-            pylint tap_dynamodb --disable 'duplicate-code,missing-module-docstring,line-too-long,fixme,missing-function-docstring,raise-missing-from,consider-using-f-string,too-many-locals,invalid-name'
+            pylint tap_dynamodb --disable 'duplicate-code,missing-module-docstring,missing-class-docstring,too-few-public-methods,line-too-long,fixme,missing-function-docstring,raise-missing-from,consider-using-f-string,too-many-locals,invalid-name,too-many-arguments'
       - run:
           name: 'Unit Tests'
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
           name: 'pylint'
           command: |
             source /usr/local/share/virtualenvs/tap-dynamodb/bin/activate
-            pylint tap_dynamodb --disable 'duplicate-code,missing-module-docstring,missing-class-docstring,too-few-public-methods,line-too-long,fixme,missing-function-docstring,raise-missing-from,consider-using-f-string,too-many-locals,invalid-name,too-many-arguments'
+            make lint
       - run:
           name: 'Unit Tests'
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
       - run:
           name: 'Tap Tester'
           command: |
-            aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/sandbox tap-tester.env
+            aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox tap-tester.env
             source tap-tester.env
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
             run-test --tap=tap-dynamodb tests
@@ -47,7 +47,9 @@ workflows:
   commit:
     jobs:
       - build:
-          context: circleci-user
+          context:
+            - circleci-user
+            - tap-tester-user
   build_daily:
     triggers:
       - schedule:
@@ -58,4 +60,6 @@ workflows:
                 - master
     jobs:
       - build:
-          context: circleci-user
+          context:
+            - circleci-user
+            - tap-tester-user

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
           name: 'pylint'
           command: |
             source /usr/local/share/virtualenvs/tap-dynamodb/bin/activate
-            pylint tap_dynamodb --disable 'duplicate-code'
+            pylint tap_dynamodb --disable 'duplicate-code,missing-module-docstring,line-too-long,fixme,missing-function-docstring,raise-missing-from,consider-using-f-string,too-many-locals,invalid-name'
       - run:
           name: 'Unit Tests'
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,7 @@
-version: 2
+version: 2.1
+orbs:
+  slack: circleci/slack@3.4.2
+
 jobs:
   build:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:tap-tester-v4
+      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester
       - image: amazon/dynamodb-local
         entrypoint: ["java", "-Xmx1G", "-jar", "DynamoDBLocal.jar"]
     steps:
@@ -36,13 +36,9 @@ jobs:
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/sandbox tap-tester.env
             source tap-tester.env
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            run-test --tap=tap-dynamodb \
-                     --target=target-stitch \
-                     --orchestrator=stitch-orchestrator \
-                     --email=harrison+sandboxtest@stitchdata.com \
-                     --password=$SANDBOX_PASSWORD \
-                     --client-id=50 \
-                     tests
+            run-test --tap=tap-dynamodb tests
+      - slack/notify-on-failure:
+          only_for_branches: master
 workflows:
   version: 2
   commit:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,17 @@ jobs:
             source /usr/local/share/virtualenvs/tap-dynamodb/bin/activate
             make lint
       - run:
+          name: 'Unit Tests'
+          command: |
+            source /usr/local/share/virtualenvs/tap-dynamodb/bin/activate
+            pip install nose coverage
+            nosetests --with-coverage --cover-erase --cover-package=tap_dynamodb --cover-html-dir=htmlcov tests/unittests
+            coverage html
+      - store_test_results:
+          path: test_output/report.xml
+      - store_artifacts:
+          path: htmlcov
+      - run:
           name: 'Tap Tester'
           command: |
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/sandbox tap-tester.env

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
           name: 'pylint'
           command: |
             source /usr/local/share/virtualenvs/tap-dynamodb/bin/activate
-            make lint
+            pylint tap_dynamodb --disable 'duplicate-code'
       - run:
           name: 'Unit Tests'
           command: |

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,6 @@ lint-tests:
 	pylint tests -d broad-except,chained-comparison,empty-docstring,fixme,invalid-name,line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-else-raise,no-else-return,too-few-public-methods,too-many-arguments,too-many-branches,too-many-lines,too-many-locals,ungrouped-imports,wrong-spelling-in-comment,wrong-spelling-in-docstring,duplicate-code,no-name-in-module,import-error,consider-using-f-string
 
 lint-code:
-	pylint tap_dynamodb -d broad-except,chained-comparison,empty-docstring,fixme,invalid-name,line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-else-raise,no-else-return,too-few-public-methods,too-many-arguments,too-many-branches,too-many-lines,too-many-locals,ungrouped-imports,wrong-spelling-in-comment,wrong-spelling-in-docstring,raise-missing-from,consider-using-f-string
+	pylint tap_dynamodb -d broad-except,chained-comparison,empty-docstring,fixme,invalid-name,line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-else-raise,no-else-return,too-few-public-methods,too-many-arguments,too-many-branches,too-many-lines,too-many-locals,ungrouped-imports,wrong-spelling-in-comment,wrong-spelling-in-docstring,raise-missing-from,consider-using-f-string,duplicate-code
 
 lint: lint-code lint-tests

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,6 @@ lint-tests:
 	pylint tests -d broad-except,chained-comparison,empty-docstring,fixme,invalid-name,line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-else-raise,no-else-return,too-few-public-methods,too-many-arguments,too-many-branches,too-many-lines,too-many-locals,ungrouped-imports,wrong-spelling-in-comment,wrong-spelling-in-docstring,duplicate-code,no-name-in-module,import-error,consider-using-f-string
 
 lint-code:
-	pylint tap_dynamodb -d broad-except,chained-comparison,empty-docstring,fixme,invalid-name,line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-else-raise,no-else-return,too-few-public-methods,too-many-arguments,too-many-branches,too-many-lines,too-many-locals,ungrouped-imports,wrong-spelling-in-comment,wrong-spelling-in-docstring,raise-missing-from,consider-using-f-string,duplicate-code
+	pylint tap_dynamodb -d broad-except,chained-comparison,empty-docstring,fixme,invalid-name,line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-else-raise,no-else-return,too-few-public-methods,too-many-arguments,too-many-branches,too-many-lines,too-many-locals,ungrouped-imports,wrong-spelling-in-comment,wrong-spelling-in-docstring,raise-missing-from,consider-using-f-string
 
 lint: lint-code lint-tests

--- a/tap_dynamodb/discover.py
+++ b/tap_dynamodb/discover.py
@@ -1,9 +1,8 @@
 from singer import metadata
 import singer
-from botocore.exceptions import ClientError
-from tap_dynamodb import dynamodb
 import backoff
 from botocore.exceptions import ClientError, ConnectTimeoutError, ReadTimeoutError
+from tap_dynamodb import dynamodb
 
 LOGGER = singer.get_logger()
 

--- a/tap_dynamodb/discover.py
+++ b/tap_dynamodb/discover.py
@@ -2,6 +2,8 @@ from singer import metadata
 import singer
 from botocore.exceptions import ClientError
 from tap_dynamodb import dynamodb
+import backoff
+from botocore.exceptions import ClientError, ConnectTimeoutError, ReadTimeoutError
 
 LOGGER = singer.get_logger()
 
@@ -29,7 +31,11 @@ def discover_table_schema(client, table_name):
         }
     }
 
-
+# Backoff for both ReadTimeout and ConnectTimeout error for 5 times
+@backoff.on_exception(backoff.expo,
+                    (ReadTimeoutError, ConnectTimeoutError),
+                    max_tries=5,
+                    factor=2)
 def discover_streams(config):
     client = dynamodb.get_client(config)
 

--- a/tap_dynamodb/dynamodb.py
+++ b/tap_dynamodb/dynamodb.py
@@ -74,15 +74,16 @@ def get_client(config):
         request_timeout = float(request_timeout)
     else: # If value is 0,"0" or "" then set default to 300 seconds.
         request_timeout = REQUEST_TIMEOUT
-    timeout_config = Config(connect_timeout=request_timeout,  read_timeout=request_timeout)
+    # add the request_timeout in both connect_timeout as well as read_timeout
+    timeout_config = Config(connect_timeout=request_timeout, read_timeout=request_timeout)
     if config.get('use_local_dynamo'):
         return boto3.client('dynamodb',
                             endpoint_url='http://localhost:8000',
                             region_name=config['region_name'],
-                            config=timeout_config
+                            config=timeout_config   # pass the config to add the request_timeout
                             )
     return boto3.client('dynamodb', config['region_name'],
-                        config=timeout_config
+                        config=timeout_config   # pass the config to add the request_timeout
                         )
 
 def get_stream_client(config):
@@ -92,14 +93,15 @@ def get_stream_client(config):
         request_timeout = float(request_timeout)
     else: # If value is 0,"0" or "" then set default to 300 seconds.
         request_timeout = REQUEST_TIMEOUT
+    # add the request_timeout in both connect_timeout as well as read_timeout
     timeout_config = Config(connect_timeout=request_timeout,  read_timeout=request_timeout)
     if config.get('use_local_dynamo'):
         return boto3.client('dynamodbstreams',
                             endpoint_url='http://localhost:8000',
                             region_name=config['region_name'],
-                            config=timeout_config
+                            config=timeout_config   # pass the config to add the request_timeout
                             )
     return boto3.client('dynamodbstreams',
                         region_name=config['region_name'],
-                        config=timeout_config
+                        config=timeout_config   # pass the config to add the request_timeout
                         )

--- a/tap_dynamodb/dynamodb.py
+++ b/tap_dynamodb/dynamodb.py
@@ -67,13 +67,18 @@ def setup_aws_client(config):
     LOGGER.info("Attempting to assume_role on RoleArn: %s", role_arn)
     boto3.setup_default_session(botocore_session=refreshable_session)
 
-def get_client(config):
+def get_request_timeout(config):
     # if request_timeout is other than 0,"0" or "" then use request_timeout
     request_timeout = config.get('request_timeout')
     if request_timeout and float(request_timeout):
         request_timeout = float(request_timeout)
     else: # If value is 0,"0" or "" then set default to 300 seconds.
         request_timeout = REQUEST_TIMEOUT
+    return request_timeout
+
+def get_client(config):
+    # get the request_timeout
+    request_timeout = get_request_timeout(config)
     # add the request_timeout in both connect_timeout as well as read_timeout
     timeout_config = Config(connect_timeout=request_timeout, read_timeout=request_timeout)
     if config.get('use_local_dynamo'):
@@ -87,12 +92,8 @@ def get_client(config):
                         )
 
 def get_stream_client(config):
-    # if request_timeout is other than 0,"0" or "" then use request_timeout
-    request_timeout = config.get('request_timeout')
-    if request_timeout and float(request_timeout):
-        request_timeout = float(request_timeout)
-    else: # If value is 0,"0" or "" then set default to 300 seconds.
-        request_timeout = REQUEST_TIMEOUT
+    # get the request_timeout
+    request_timeout = get_request_timeout(config)
     # add the request_timeout in both connect_timeout as well as read_timeout
     timeout_config = Config(connect_timeout=request_timeout,  read_timeout=request_timeout)
     if config.get('use_local_dynamo'):

--- a/tap_dynamodb/sync_strategies/full_table.py
+++ b/tap_dynamodb/sync_strategies/full_table.py
@@ -2,10 +2,10 @@ import time
 
 import singer
 from singer import metadata
-from tap_dynamodb import dynamodb
 from tap_dynamodb.deserialize import Deserializer
 import backoff
-from botocore.exceptions import ClientError, ConnectTimeoutError, ReadTimeoutError
+from botocore.exceptions import ConnectTimeoutError, ReadTimeoutError
+from tap_dynamodb import dynamodb
 
 LOGGER = singer.get_logger()
 

--- a/tap_dynamodb/sync_strategies/full_table.py
+++ b/tap_dynamodb/sync_strategies/full_table.py
@@ -4,10 +4,15 @@ import singer
 from singer import metadata
 from tap_dynamodb import dynamodb
 from tap_dynamodb.deserialize import Deserializer
+import backoff
+from botocore.exceptions import ClientError, ConnectTimeoutError, ReadTimeoutError
 
 LOGGER = singer.get_logger()
 
-
+@backoff.on_exception(backoff.expo,
+                          (ReadTimeoutError, ConnectTimeoutError),
+                          max_tries=5,
+                          factor=2)
 def scan_table(table_name, projection, last_evaluated_key, config):
     scan_params = {
         'TableName': table_name,

--- a/tap_dynamodb/sync_strategies/full_table.py
+++ b/tap_dynamodb/sync_strategies/full_table.py
@@ -2,9 +2,9 @@ import time
 
 import singer
 from singer import metadata
-from tap_dynamodb.deserialize import Deserializer
 import backoff
 from botocore.exceptions import ConnectTimeoutError, ReadTimeoutError
+from tap_dynamodb.deserialize import Deserializer
 from tap_dynamodb import dynamodb
 
 LOGGER = singer.get_logger()

--- a/tap_dynamodb/sync_strategies/full_table.py
+++ b/tap_dynamodb/sync_strategies/full_table.py
@@ -39,9 +39,9 @@ def scan_table(table_name, projection, last_evaluated_key, config):
 
 # Backoff for both ReadTimeout and ConnectTimeout error for 5 times
 @backoff.on_exception(backoff.expo,
-                          (ReadTimeoutError, ConnectTimeoutError),
-                          max_tries=5,
-                          factor=2)
+                      (ReadTimeoutError, ConnectTimeoutError),
+                      max_tries=5,
+                      factor=2)
 def sync(config, state, stream):
     table_name = stream['tap_stream_id']
 

--- a/tap_dynamodb/sync_strategies/full_table.py
+++ b/tap_dynamodb/sync_strategies/full_table.py
@@ -9,10 +9,7 @@ from botocore.exceptions import ClientError, ConnectTimeoutError, ReadTimeoutErr
 
 LOGGER = singer.get_logger()
 
-@backoff.on_exception(backoff.expo,
-                          (ReadTimeoutError, ConnectTimeoutError),
-                          max_tries=5,
-                          factor=2)
+
 def scan_table(table_name, projection, last_evaluated_key, config):
     scan_params = {
         'TableName': table_name,
@@ -40,7 +37,11 @@ def scan_table(table_name, projection, last_evaluated_key, config):
 
         has_more = result.get('LastEvaluatedKey', False)
 
-
+# Backoff for both ReadTimeout and ConnectTimeout error for 5 times
+@backoff.on_exception(backoff.expo,
+                          (ReadTimeoutError, ConnectTimeoutError),
+                          max_tries=5,
+                          factor=2)
 def sync(config, state, stream):
     table_name = stream['tap_stream_id']
 

--- a/tap_dynamodb/sync_strategies/log_based.py
+++ b/tap_dynamodb/sync_strategies/log_based.py
@@ -9,7 +9,8 @@ LOGGER = singer.get_logger()
 WRITE_STATE_PERIOD = 1000
 
 SDC_DELETED_AT = "_sdc_deleted_at"
-
+MAX_TRIES = 5
+FACTOR = 2
 
 def get_shards(streams_client, stream_arn):
     '''
@@ -118,8 +119,8 @@ def sync_shard(shard, seq_number_bookmarks, streams_client, stream_arn, projecti
 # Backoff for both ReadTimeout and ConnectTimeout error for 5 times
 @backoff.on_exception(backoff.expo,
                       (ReadTimeoutError, ConnectTimeoutError),
-                      max_tries=5,
-                      factor=2)
+                      max_tries=MAX_TRIES,
+                      factor=FACTOR)
 def sync(config, state, stream):
     table_name = stream['tap_stream_id']
 
@@ -219,8 +220,8 @@ def has_stream_aged_out(state, table_name):
 # Backoff for both ReadTimeout and ConnectTimeout error for 5 times
 @backoff.on_exception(backoff.expo,
                       (ReadTimeoutError, ConnectTimeoutError),
-                      max_tries=5,
-                      factor=2)
+                      max_tries=MAX_TRIES,
+                      factor=FACTOR)
 def get_initial_bookmarks(config, state, table_name):
     '''
     Returns the state including all bookmarks necessary for the initial

--- a/tap_dynamodb/sync_strategies/log_based.py
+++ b/tap_dynamodb/sync_strategies/log_based.py
@@ -4,6 +4,8 @@ import singer
 
 from tap_dynamodb import dynamodb
 from tap_dynamodb import deserialize
+import backoff
+from botocore.exceptions import ConnectTimeoutError, ReadTimeoutError
 
 LOGGER = singer.get_logger()
 WRITE_STATE_PERIOD = 1000
@@ -115,7 +117,11 @@ def sync_shard(shard, seq_number_bookmarks, streams_client, stream_arn, projecti
     singer.write_state(state)
     return rows_synced
 
-
+# Backoff for both ReadTimeout and ConnectTimeout error for 5 times
+@backoff.on_exception(backoff.expo,
+                          (ReadTimeoutError, ConnectTimeoutError),
+                          max_tries=5,
+                          factor=2)
 def sync(config, state, stream):
     table_name = stream['tap_stream_id']
 
@@ -212,7 +218,10 @@ def has_stream_aged_out(state, table_name):
     # stream then we consider the stream to be aged out
     return time_span > datetime.timedelta(hours=19, minutes=30)
 
-
+@backoff.on_exception(backoff.expo,
+                          (ReadTimeoutError, ConnectTimeoutError),
+                          max_tries=5,
+                          factor=2)
 def get_initial_bookmarks(config, state, table_name):
     '''
     Returns the state including all bookmarks necessary for the initial

--- a/tap_dynamodb/sync_strategies/log_based.py
+++ b/tap_dynamodb/sync_strategies/log_based.py
@@ -117,9 +117,9 @@ def sync_shard(shard, seq_number_bookmarks, streams_client, stream_arn, projecti
 
 # Backoff for both ReadTimeout and ConnectTimeout error for 5 times
 @backoff.on_exception(backoff.expo,
-                          (ReadTimeoutError, ConnectTimeoutError),
-                          max_tries=5,
-                          factor=2)
+                      (ReadTimeoutError, ConnectTimeoutError),
+                      max_tries=5,
+                      factor=2)
 def sync(config, state, stream):
     table_name = stream['tap_stream_id']
 

--- a/tap_dynamodb/sync_strategies/log_based.py
+++ b/tap_dynamodb/sync_strategies/log_based.py
@@ -1,10 +1,9 @@
 import datetime
 from singer import metadata
 import singer
-from tap_dynamodb import deserialize
 import backoff
 from botocore.exceptions import ConnectTimeoutError, ReadTimeoutError
-from tap_dynamodb import dynamodb
+from tap_dynamodb import dynamodb, deserialize
 
 LOGGER = singer.get_logger()
 WRITE_STATE_PERIOD = 1000

--- a/tap_dynamodb/sync_strategies/log_based.py
+++ b/tap_dynamodb/sync_strategies/log_based.py
@@ -216,10 +216,11 @@ def has_stream_aged_out(state, table_name):
     # stream then we consider the stream to be aged out
     return time_span > datetime.timedelta(hours=19, minutes=30)
 
+# Backoff for both ReadTimeout and ConnectTimeout error for 5 times
 @backoff.on_exception(backoff.expo,
-                          (ReadTimeoutError, ConnectTimeoutError),
-                          max_tries=5,
-                          factor=2)
+                      (ReadTimeoutError, ConnectTimeoutError),
+                      max_tries=5,
+                      factor=2)
 def get_initial_bookmarks(config, state, table_name):
     '''
     Returns the state including all bookmarks necessary for the initial

--- a/tap_dynamodb/sync_strategies/log_based.py
+++ b/tap_dynamodb/sync_strategies/log_based.py
@@ -1,11 +1,10 @@
 import datetime
 from singer import metadata
 import singer
-
-from tap_dynamodb import dynamodb
 from tap_dynamodb import deserialize
 import backoff
 from botocore.exceptions import ConnectTimeoutError, ReadTimeoutError
+from tap_dynamodb import dynamodb
 
 LOGGER = singer.get_logger()
 WRITE_STATE_PERIOD = 1000

--- a/tests/test_dynamodb_discovery.py
+++ b/tests/test_dynamodb_discovery.py
@@ -1,6 +1,5 @@
 from boto3.dynamodb.types import TypeSerializer
 
-from tap_tester.scenario import (SCENARIOS)
 from base import TestDynamoDBBase
 
 
@@ -53,6 +52,3 @@ class DynamoDBDiscovery(TestDynamoDBBase):
 
     def test_run(self):
         self.pre_sync_test()
-
-
-SCENARIOS.add(DynamoDBDiscovery)

--- a/tests/test_dynamodb_full_table_interruptible_sync.py
+++ b/tests/test_dynamodb_full_table_interruptible_sync.py
@@ -3,7 +3,6 @@ import singer
 
 from boto3.dynamodb.types import TypeSerializer
 
-from tap_tester.scenario import (SCENARIOS)
 from tap_tester import connections
 from tap_tester import menagerie
 from tap_tester import runner
@@ -129,6 +128,3 @@ class DynamoDBFullTableInterruptible(TestDynamoDBBase):
             self.assertIsNone(state['bookmarks'][table_name].get('last_evaluated_key'))
 
             self.assertTrue(state['bookmarks'][table_name].get('initial_full_table_complete', False))
-
-
-SCENARIOS.add(DynamoDBFullTableInterruptible)

--- a/tests/test_dynamodb_full_table_sync.py
+++ b/tests/test_dynamodb_full_table_sync.py
@@ -4,7 +4,6 @@ import singer
 
 from boto3.dynamodb.types import TypeSerializer
 
-from tap_tester.scenario import (SCENARIOS)
 from tap_tester import connections
 from tap_tester import menagerie
 from tap_tester import runner
@@ -108,5 +107,3 @@ class DynamoDBFullTable(TestDynamoDBBase):
             # assert that there is a version bookmark in state
             first_versions[table_name] = state['bookmarks'][table_name]['version']
             self.assertIsNotNone(first_versions[table_name])
-
-SCENARIOS.add(DynamoDBFullTable)

--- a/tests/test_dynamodb_log_based.py
+++ b/tests/test_dynamodb_log_based.py
@@ -2,7 +2,6 @@ import singer
 
 from boto3.dynamodb.types import TypeSerializer
 
-from tap_tester.scenario import (SCENARIOS)
 from tap_tester import connections
 from tap_tester import menagerie
 from tap_tester import runner
@@ -143,6 +142,3 @@ class DynamoDBLogBased(TestDynamoDBBase):
             self.assertEqual(31, len(stream['messages']))
 
         state = menagerie.get_state(conn_id)
-
-
-SCENARIOS.add(DynamoDBLogBased)

--- a/tests/test_dynamodb_log_based_interruptible.py
+++ b/tests/test_dynamodb_log_based_interruptible.py
@@ -2,7 +2,6 @@ import singer
 
 from boto3.dynamodb.types import TypeSerializer
 
-from tap_tester.scenario import (SCENARIOS)
 from tap_tester import connections
 from tap_tester import menagerie
 from tap_tester import runner
@@ -202,7 +201,3 @@ class DynamoDBLogBased(TestDynamoDBBase):
             # as the full table sync
             state['bookmarks'][table_name].pop('finished_shards')
             menagerie.set_state(conn_id, state, version=state_version)
-
-
-
-SCENARIOS.add(DynamoDBLogBased)

--- a/tests/test_dynamodb_log_based_projections.py
+++ b/tests/test_dynamodb_log_based_projections.py
@@ -3,7 +3,6 @@ import singer
 
 from boto3.dynamodb.types import TypeSerializer
 
-from tap_tester.scenario import (SCENARIOS)
 from tap_tester import connections
 from tap_tester import menagerie
 from tap_tester import runner
@@ -205,6 +204,3 @@ class DynamoDBLogBasedProjections(TestDynamoDBBase):
                         for list_key in config['top_level_list_keys']:
                             self.assertTrue(isinstance(message['data'][list_key], list))
                         self.assertEqual(config['nested_map_keys']['map_field'], {*message['data']['map_field'].keys()})
-
-
-SCENARIOS.add(DynamoDBLogBasedProjections)

--- a/tests/test_dynamodb_projections.py
+++ b/tests/test_dynamodb_projections.py
@@ -3,7 +3,6 @@ import singer
 
 from boto3.dynamodb.types import TypeSerializer
 
-from tap_tester.scenario import (SCENARIOS)
 from tap_tester import connections
 from tap_tester import menagerie
 from tap_tester import runner
@@ -134,6 +133,3 @@ class DynamoDBProjections(TestDynamoDBBase):
                         for list_key in config['top_level_list_keys']:
                             self.assertTrue(isinstance(message['data'][list_key], list))
                         self.assertEqual(config['nested_map_keys']['map_field'], {*message['data']['map_field'].keys()})
-
-
-SCENARIOS.add(DynamoDBProjections)

--- a/tests/unittests/test_request_timeout.py
+++ b/tests/unittests/test_request_timeout.py
@@ -1,0 +1,142 @@
+from tap_dynamodb.sync_strategies import full_table, log_based
+from tap_dynamodb import discover, dynamodb
+import tap_dynamodb
+import unittest
+from unittest import mock
+from unittest.mock import Mock
+from unittest.case import TestCase
+from botocore.exceptions import ClientError, ConnectTimeoutError, ReadTimeoutError
+
+class MockClient():
+    def __init__(self, endpoint_url=None):
+        pass
+
+    def list_tables(self):
+        pass
+
+
+
+class TestBackoffError(unittest.TestCase):
+    '''
+    Test that backoff logic works properly.
+    '''
+    # @mock.patch('tap_dynamodb.dynamodb.boto3.client', return_value=MockClient())
+    @mock.patch('boto3.client')
+    @mock.patch('singer.metadata.to_map')
+    def test_discover_stream_request_timeout_and_backoff(self, mock_map, mock_client):
+        """
+        Check whether the request backoffs properly for list_tables for 5 times in case of Timeout error.
+        """
+        mock_client.list_tables.side_effect = ReadTimeoutError
+        # mock_client = Mock()
+        # mock_client.list_tables = Mock()
+
+        with self.assertRaises(ReadTimeoutError):
+            # log_based.sync({"region_name": "us-east-2"}, {}, {"tap_stream_id": "dummy", "metadata":""})
+            discover.discover_streams({"region_name": "dummy", "use_local_dynamo": "true"})
+        self.assertEquals(mock_client.list_tables.call_count, 5)
+
+
+class TestRequestTimeoutValue(unittest.TestCase):
+    '''
+    Test that request timeout parameter works properly in various cases
+    '''
+    @mock.patch('boto3.client')
+    @mock.patch("tap_dynamodb.dynamodb.Config")
+    def test_config_provided_request_timeout(self, mock_config, mock_client):
+        """ 
+            Unit tests to ensure that request timeout is set based on config value
+        """
+        config = {"region_name": "dummy_region", "request_timeout": 100}
+        dynamodb.get_client(config)
+        mock_config.assert_called_with(connect_timeout=100, read_timeout=100)
+
+    @mock.patch('boto3.client')
+    @mock.patch("tap_dynamodb.dynamodb.Config")
+    def test_default_value_request_timeout(self, mock_config, mock_client):
+        """ 
+            Unit tests to ensure that request timeout is set based default value
+        """
+        config = {"region_name": "dummy_region"}
+        dynamodb.get_client(config)
+        mock_config.assert_called_with(connect_timeout=300, read_timeout=300)
+
+    @mock.patch('boto3.client')
+    @mock.patch("tap_dynamodb.dynamodb.Config")
+    def test_config_provided_empty_request_timeout(self, mock_config, mock_client):
+        """ 
+            Unit tests to ensure that request timeout is set based on default value if empty value is given in config
+        """
+        config = {"region_name": "dummy_region", "request_timeout": ""}
+        dynamodb.get_client(config)
+        mock_config.assert_called_with(connect_timeout=300, read_timeout=300)
+
+    @mock.patch('boto3.client')
+    @mock.patch("tap_dynamodb.dynamodb.Config")
+    def test_config_provided_string_request_timeout(self, mock_config, mock_client):
+        """ 
+            Unit tests to ensure that request timeout is set based on config string value
+        """
+        config = {"region_name": "dummy_region", "request_timeout": "100"}
+        dynamodb.get_client(config)
+        mock_config.assert_called_with(connect_timeout=100, read_timeout=100)
+
+    @mock.patch('boto3.client')
+    @mock.patch("tap_dynamodb.dynamodb.Config")
+    def test_config_provided_float_request_timeout(self, mock_config, mock_client):
+        """ 
+            Unit tests to ensure that request timeout is set based on config float value
+        """
+        config = {"region_name": "dummy_region", "request_timeout": 100.8}
+        dynamodb.get_client(config)
+        mock_config.assert_called_with(connect_timeout=100.8, read_timeout=100.8)
+
+    @mock.patch('boto3.client')
+    @mock.patch("tap_dynamodb.dynamodb.Config")
+    def test_stream_config_provided_request_timeout(self, mock_config, mock_client):
+        """ 
+            Unit tests to ensure that request timeout is set based on config value
+        """
+        config = {"region_name": "dummy_region", "request_timeout": 100}
+        dynamodb.get_stream_client(config)
+        mock_config.assert_called_with(connect_timeout=100, read_timeout=100)
+
+    @mock.patch('boto3.client')
+    @mock.patch("tap_dynamodb.dynamodb.Config")
+    def test_stream_default_value_request_timeout(self, mock_config, mock_client):
+        """ 
+            Unit tests to ensure that request timeout is set based default value
+        """
+        config = {"region_name": "dummy_region"}
+        dynamodb.get_stream_client(config)
+        mock_config.assert_called_with(connect_timeout=300, read_timeout=300)
+
+    @mock.patch('boto3.client')
+    @mock.patch("tap_dynamodb.dynamodb.Config")
+    def test_stream_config_provided_empty_request_timeout(self, mock_config, mock_client):
+        """ 
+            Unit tests to ensure that request timeout is set based on default value if empty value is given in config
+        """
+        config = {"region_name": "dummy_region", "request_timeout": ""}
+        dynamodb.get_stream_client(config)
+        mock_config.assert_called_with(connect_timeout=300, read_timeout=300)
+
+    @mock.patch('boto3.client')
+    @mock.patch("tap_dynamodb.dynamodb.Config")
+    def test_stream_config_provided_string_request_timeout(self, mock_config, mock_client):
+        """ 
+            Unit tests to ensure that request timeout is set based on config string value
+        """
+        config = {"region_name": "dummy_region", "request_timeout": "100"}
+        dynamodb.get_stream_client(config)
+        mock_config.assert_called_with(connect_timeout=100, read_timeout=100)
+
+    @mock.patch('boto3.client')
+    @mock.patch("tap_dynamodb.dynamodb.Config")
+    def test_stream_config_provided_float_request_timeout(self, mock_config, mock_client):
+        """ 
+            Unit tests to ensure that request timeout is set based on config float value
+        """
+        config = {"region_name": "dummy_region", "request_timeout": 100.8}
+        dynamodb.get_stream_client(config)
+        mock_config.assert_called_with(connect_timeout=100.8, read_timeout=100.8)

--- a/tests/unittests/test_request_timeout.py
+++ b/tests/unittests/test_request_timeout.py
@@ -103,6 +103,15 @@ class TestBackoffError(unittest.TestCase):
         self.assertEqual(mock_client.call_count, 5)
         self.assertEqual(mock_stream_client.call_count, 5)
 
+    @mock.patch('tap_dynamodb.dynamodb.get_client',side_effect=mock_get_client)
+    def test_get_initial_bookmarks_read_timeout_and_backoff(self, mock_client):
+        """
+        Check whether the request backoffs properly for discover_streams for 5 times in case of ReadTimeoutError error.
+        """
+        with self.assertRaises(ReadTimeoutError):
+            log_based.get_initial_bookmarks({"region_name": "dummy", "use_local_dynamo": "true"}, {}, "dummy_table")
+        self.assertEquals(mock_client.call_count, 5)
+
 class TestRequestTimeoutValue(unittest.TestCase):
     '''
     Test that request timeout parameter works properly in various cases

--- a/tests/unittests/test_request_timeout.py
+++ b/tests/unittests/test_request_timeout.py
@@ -1,11 +1,9 @@
 from tap_dynamodb.sync_strategies import full_table, log_based
-from tap_dynamodb import LOGGER, discover, dynamodb
+from tap_dynamodb import discover, dynamodb
 import tap_dynamodb
 import unittest
 from unittest import mock
-from unittest.mock import Mock
-from unittest.case import TestCase
-from botocore.exceptions import ClientError, ConnectTimeoutError, ReadTimeoutError
+from botocore.exceptions import ConnectTimeoutError, ReadTimeoutError
 
 class MockClient():
     def __init__(self,endpoint_url=None):

--- a/tests/unittests/test_request_timeout.py
+++ b/tests/unittests/test_request_timeout.py
@@ -114,15 +114,17 @@ class TestRequestTimeoutValue(unittest.TestCase):
     '''
     Test that request timeout parameter works properly in various cases
     '''
+    default_timeout_value = 300
     @mock.patch('boto3.client')
     @mock.patch("tap_dynamodb.dynamodb.Config")
     def test_config_provided_request_timeout(self, mock_config, mock_client):
         """ 
             Unit tests to ensure that request timeout is set based on config value
         """
-        config = {"region_name": "dummy_region", "request_timeout": 100}
+        timeout_value = 100
+        config = {"region_name": "dummy_region", "request_timeout": timeout_value}
         dynamodb.get_client(config)
-        mock_config.assert_called_with(connect_timeout=100, read_timeout=100)
+        mock_config.assert_called_with(connect_timeout=timeout_value, read_timeout=timeout_value)
 
     @mock.patch('boto3.client')
     @mock.patch("tap_dynamodb.dynamodb.Config")
@@ -132,7 +134,7 @@ class TestRequestTimeoutValue(unittest.TestCase):
         """
         config = {"region_name": "dummy_region"}
         dynamodb.get_client(config)
-        mock_config.assert_called_with(connect_timeout=300, read_timeout=300)
+        mock_config.assert_called_with(connect_timeout=self.default_timeout_value, read_timeout=self.default_timeout_value)
 
     @mock.patch('boto3.client')
     @mock.patch("tap_dynamodb.dynamodb.Config")
@@ -142,7 +144,7 @@ class TestRequestTimeoutValue(unittest.TestCase):
         """
         config = {"region_name": "dummy_region", "request_timeout": ""}
         dynamodb.get_client(config)
-        mock_config.assert_called_with(connect_timeout=300, read_timeout=300)
+        mock_config.assert_called_with(connect_timeout=self.default_timeout_value, read_timeout=self.default_timeout_value)
 
     @mock.patch('boto3.client')
     @mock.patch("tap_dynamodb.dynamodb.Config")
@@ -160,9 +162,10 @@ class TestRequestTimeoutValue(unittest.TestCase):
         """ 
             Unit tests to ensure that request timeout is set based on config float value
         """
-        config = {"region_name": "dummy_region", "request_timeout": 100.8}
+        timeout_value = 100.8
+        config = {"region_name": "dummy_region", "request_timeout": timeout_value}
         dynamodb.get_client(config)
-        mock_config.assert_called_with(connect_timeout=100.8, read_timeout=100.8)
+        mock_config.assert_called_with(connect_timeout=timeout_value, read_timeout=timeout_value)
 
     @mock.patch('boto3.client')
     @mock.patch("tap_dynamodb.dynamodb.Config")
@@ -170,9 +173,10 @@ class TestRequestTimeoutValue(unittest.TestCase):
         """ 
             Unit tests to ensure that request timeout is set based on config value
         """
-        config = {"region_name": "dummy_region", "request_timeout": 100}
+        timeout_value = 100
+        config = {"region_name": "dummy_region", "request_timeout": timeout_value}
         dynamodb.get_stream_client(config)
-        mock_config.assert_called_with(connect_timeout=100, read_timeout=100)
+        mock_config.assert_called_with(connect_timeout=timeout_value, read_timeout=timeout_value)
 
     @mock.patch('boto3.client')
     @mock.patch("tap_dynamodb.dynamodb.Config")
@@ -182,7 +186,7 @@ class TestRequestTimeoutValue(unittest.TestCase):
         """
         config = {"region_name": "dummy_region"}
         dynamodb.get_stream_client(config)
-        mock_config.assert_called_with(connect_timeout=300, read_timeout=300)
+        mock_config.assert_called_with(connect_timeout=self.default_timeout_value, read_timeout=self.default_timeout_value)
 
     @mock.patch('boto3.client')
     @mock.patch("tap_dynamodb.dynamodb.Config")
@@ -192,7 +196,7 @@ class TestRequestTimeoutValue(unittest.TestCase):
         """
         config = {"region_name": "dummy_region", "request_timeout": ""}
         dynamodb.get_stream_client(config)
-        mock_config.assert_called_with(connect_timeout=300, read_timeout=300)
+        mock_config.assert_called_with(connect_timeout=self.default_timeout_value, read_timeout=self.default_timeout_value)
 
     @mock.patch('boto3.client')
     @mock.patch("tap_dynamodb.dynamodb.Config")
@@ -210,6 +214,7 @@ class TestRequestTimeoutValue(unittest.TestCase):
         """ 
             Unit tests to ensure that request timeout is set based on config float value
         """
-        config = {"region_name": "dummy_region", "request_timeout": 100.8}
+        timeout_value = 100.8
+        config = {"region_name": "dummy_region", "request_timeout": timeout_value}
         dynamodb.get_stream_client(config)
-        mock_config.assert_called_with(connect_timeout=100.8, read_timeout=100.8)
+        mock_config.assert_called_with(connect_timeout=timeout_value, read_timeout=timeout_value)


### PR DESCRIPTION
Description of change
Added request timeout for SDK library functions with default timeout 300 seconds

Manual QA steps

- The request should backoff 5 times in case it is timed out.
- Error should be thrown in case of retries not successful after 5 trials
- Checked the request timeout works for each stream and backoff

# Risks
 - 
 
# Rollback steps
 - revert this branch
