### PR TITLE
Add failing test case for decimal.rounded case to log based

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -21,12 +21,12 @@ ALL_TABLE_NAMES_TO_CLEAR = frozenset({
 })
 
 LOGGER = singer.get_logger()
-decimal_index = 0
 
 
 class TestDynamoDBBase(unittest.TestCase):
     _client = None
     _streams_client = None
+    decimal_index = 0
 
     def expected_table_config(self):
         raise NotImplementedError
@@ -151,9 +151,9 @@ class TestDynamoDBBase(unittest.TestCase):
         return ''.join(random.choice(chars) for x in range(size))
 
     @staticmethod
-    def random_decimal_generator(digits=string.digits):
+    def random_decimal_generator(self):
         # Refactor per PR review
-        # List boundry cases
+        # List boundry cases (20)
         # max exponent with max precision and max digit magnitute 0.999...e126 (pos and neg)
         # min exponent with max precision and max digit magnitute 0.999...e-128 (pos and neg)
         # TODO card out test overflow of above two cases?
@@ -182,11 +182,8 @@ class TestDynamoDBBase(unittest.TestCase):
             '0.1234567890e88',
             '-0.98765432109876543210e-99']
 
-        global decimal_index
-        #print(f'decimal_index: {decimal_index}')
-        num = decimal_list[decimal_index % len(decimal_list)]
-        decimal_index += 1
-        #print(num)
+        num = decimal_list[self.decimal_index % len(decimal_list)]
+        self.decimal_index += 1
 
         return decimal.Decimal(num)
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -150,27 +150,16 @@ class TestDynamoDBBase(unittest.TestCase):
     def random_string_generator(size=6, chars=string.ascii_uppercase + string.digits):
         return ''.join(random.choice(chars) for x in range(size))
 
-    #@staticmethod # TODO is this needed?
     def random_decimal_generator(self):
-        # Refactor per PR review
-        # List boundry cases (20)
-        # max exponent with max precision and max digit magnitute 0.999...e126 (pos and neg)
-        # min exponent with max precision and max digit magnitute 0.999...e-128 (pos and neg)
-        # TODO card out test overflow of above two cases?
-        # no exponent with min precision and whatever digit magnitude (pos and neg) 0, -0, 8, -3
-        # more complex zero with exponent
-        # 8 random middle exponent, sign, precision
-        # 3 random middle precision, sign no exponent
-        # TODO other boundries?
 
         decimal_list = [
             '12345', '-21', '98765432109876543210987654321098765432',
             '0', '-3', '8', '-0',
             '0.99999999999999999999999999999999999999e126',
             '-0.99999999999999999999999999999999999999e126',
-            #'0.99999999999999999999999999999999999999e-128', % TODO why does this fail?
+            #'0.99999999999999999999999999999999999999e-128', # BUG https://jira.talendforge.org/browse/TDL-19357
             '0.9999999999999999999999999999999999999e-128',
-            #'-0.99999999999999999999999999999999999999e-128', # TODO why does this fail?
+            #'-0.99999999999999999999999999999999999999e-128', # BUG https://jira.talendforge.org/browse/TDL-19357
             '-0.9999999999999999999999999999999999999e-128',
             '00000000000000000000.000000000000000000e100',
             '1.598738596902e55',
@@ -180,7 +169,7 @@ class TestDynamoDBBase(unittest.TestCase):
             '9.99999999999999999999999999777e123',
             '-9.88888888888888888888888888888e-124',
             '0.1234567890e88',
-            '-0.98765432109876543210e-99']
+            '-0.98765432109876543210e-99' ]
 
         num = decimal_list[self.decimal_index % len(decimal_list)]
         self.decimal_index += 1

--- a/tests/base.py
+++ b/tests/base.py
@@ -150,7 +150,7 @@ class TestDynamoDBBase(unittest.TestCase):
     def random_string_generator(size=6, chars=string.ascii_uppercase + string.digits):
         return ''.join(random.choice(chars) for x in range(size))
 
-    @staticmethod
+    #@staticmethod # TODO is this needed?
     def random_decimal_generator(self):
         # Refactor per PR review
         # List boundry cases (20)

--- a/tests/test_dynamodb_log_based.py
+++ b/tests/test_dynamodb_log_based.py
@@ -28,7 +28,7 @@ class DynamoDBLogBased(TestDynamoDBBase):
                 'int_id': i,
                 'string_field': self.random_string_generator(),
                 # BUG https://jira.talendforge.org/browse/TDL-19094
-                #'decimal_field': self.random_decimal_generator(self),
+                #'decimal_field': self.random_decimal_generator(),
                 'boolean_field': True,
             }
             yield serializer.serialize(record)

--- a/tests/test_dynamodb_log_based.py
+++ b/tests/test_dynamodb_log_based.py
@@ -27,6 +27,8 @@ class DynamoDBLogBased(TestDynamoDBBase):
             record = {
                 'int_id': i,
                 'string_field': self.random_string_generator(),
+                # BUG https://jira.talendforge.org/browse/TDL-19094
+                #'decimal_field': self.random_decimal_generator(),
                 'boolean_field': True,
             }
             yield serializer.serialize(record)

--- a/tests/test_dynamodb_log_based.py
+++ b/tests/test_dynamodb_log_based.py
@@ -28,7 +28,7 @@ class DynamoDBLogBased(TestDynamoDBBase):
                 'int_id': i,
                 'string_field': self.random_string_generator(),
                 # BUG https://jira.talendforge.org/browse/TDL-19094
-                #'decimal_field': self.random_decimal_generator(),
+                #'decimal_field': self.random_decimal_generator(self),
                 'boolean_field': True,
             }
             yield serializer.serialize(record)


### PR DESCRIPTION
# Description of change
Added decimal data type to the log based replication test based on TDL-16037, and TDL-16136.  Found additional edge cases were still hitting the error.  Generated TDL-19094 to resolve remaining error cases.

# Manual QA steps
None
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
