### PR TITLE
Parallel scan in Full Table strategy

### DIFF
--- a/tap_dynamodb/sync_strategies/full_table.py
+++ b/tap_dynamodb/sync_strategies/full_table.py
@@ -13,10 +13,20 @@ def scan_table(table_name, projection, expression, last_evaluated_key, config):
     '''
     Get all the records of the table by using `scan()` method with projection expression parameters
     '''
+
+    # parallelize large scans
+    parallel_segment = config.get("parallel_segment", None)
+    parallel_totalsegments = config.get("parallel_totalsegments", None)
+
     scan_params = {
         'TableName': table_name,
         'Limit': 1000
     }
+    
+    # add the parallel segment and the total number of segments in the parameters to the `scan`
+    if parallel_segment and parallel_totalsegments:
+        scan_params["Segment"] = int(parallel_segment)
+        scan_params["TotalSegments"] = int(parallel_totalsegments)
 
     # add the projection expression in the parameters to the `scan`
     if projection is not None and projection != '':


### PR DESCRIPTION
# Description of change
According to the AWS documentation [here](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Scan.html#Scan.ParallelScan), there is a possibility to Scan a DynamoDB table in parallel. This is useful for large scans, as by default, the Scan operation returns data to the application in 1 MB increments.

# Manual QA steps
In order to run the tap in parallel, we need to specify as environment variables, the following attributes:
- ```parallel_segment```: specify the segment ID.
- ```parallel_totalsegments``` : specify the total number of segments. 
# Risks
 - 
 
# Rollback steps
 - revert this branch

# Additional info
https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Scan.html#Scan.ParallelScan

_the Scan operation can logically divide a table or secondary index into multiple segments, with multiple application workers scanning the segments in parallel. Each worker can be a thread._

In order to run a Parallel scan, we need to run multiple executions of the tap, each one with different `parallel_segment` attribute value. But the same `parallel_totalsegments`.
So for example:

- Execution 1:
   - parallel_segment = 0
   - parallel_totalsegments = 2

- Execution 2:
   - parallel_segment = 1
   - parallel_totalsegments = 2

⚠️The first parallel_segment must start at 0.
