### PR TITLE
Fix error handling for incorrectly set up log based streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.2.3
+  * Fix error handling for log-based setup [#50](https://github.com/singer-io/tap-dynamodb/pull/50)
+
 ## 1.2.2
   * Fix empty string projection filter [#49](https://github.com/singer-io/tap-dynamodb/pull/49)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-dynamodb",
-    version="1.2.2",
+    version="1.2.3",
     description="Singer.io tap for extracting data",
     author="Stitch",
     url="http://singer.io",

--- a/tap_dynamodb/sync_strategies/log_based.py
+++ b/tap_dynamodb/sync_strategies/log_based.py
@@ -88,10 +88,11 @@ def sync_shard(shard, seq_number_bookmarks, streams_client, stream_arn, projecti
             record_message = deserializer.deserialize_item(record['dynamodb']['Keys'])
             record_message[SDC_DELETED_AT] = singer.utils.strftime(record['dynamodb']['ApproximateCreationDateTime'])
         else:
-            record_message = deserializer.deserialize_item(record['dynamodb'].get('NewImage'))
-            if record_message is None:
+            new_image = record['dynamodb'].get('NewImage')
+            if new_image is None:
                 LOGGER.fatal('Dynamo stream view type must be either "NEW_IMAGE" "NEW_AND_OLD_IMAGES"')
                 raise RuntimeError('Dynamo stream view type must be either "NEW_IMAGE" "NEW_AND_OLD_IMAGES"')
+            record_message = deserializer.deserialize_item(new_image)
             if projection is not None and projection != '':
                 try:
                     record_message = deserializer.apply_projection(record_message, projection)


### PR DESCRIPTION
# Description of change
The `deserializer.deserialize_item` will not return None if the incorrect object is passed in, it will throw an `AttributeError: 'NoneType' object has no attribute 'items'` . This PR fixes the error handling to check if the record contains `NewImage` before deserializing, to throw the correct actionable error. 

# Manual QA steps
 - tested locally with clients connection
 
# Risks
 - low, the tap should not throw an actionable error message if log based is not set up correctly
 
# Rollback steps
 - revert this branch
