### PR TITLE
Implement Refreshable Chained AWS Session for Multi-Account Role Assumption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.4.0
+  * Adds proxy AWS Account as a middleware to mask the Qlik AWS account ID [#59](https://github.com/singer-io/tap-dynamodb/pull/59)
+
 ## 1.3.0
   * Updates to run on python 3.11.7 [#57](https://github.com/singer-io/tap-dynamodb/pull/57)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 1.4.0
-  * Adds proxy AWS Account as a middleware to mask the Qlik AWS account ID [#59](https://github.com/singer-io/tap-dynamodb/pull/59)
+  * Adds proxy AWS Account support [#59](https://github.com/singer-io/tap-dynamodb/pull/59)
 
 ## 1.3.0
   * Updates to run on python 3.11.7 [#57](https://github.com/singer-io/tap-dynamodb/pull/57)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-dynamodb",
-    version="1.3.0",
+    version="1.4.0",
     description="Singer.io tap for extracting data",
     author="Stitch",
     url="http://singer.io",

--- a/tap_dynamodb/__init__.py
+++ b/tap_dynamodb/__init__.py
@@ -12,7 +12,7 @@ from tap_dynamodb.sync import sync_stream
 
 LOGGER = singer.get_logger()
 
-REQUIRED_CONFIG_KEYS = ["account_id", "external_id", "role_name", "region_name"]
+REQUIRED_CONFIG_KEYS = ["account_id", "external_id", "role_name", "region_name", "proxy_account_id", "proxy_external_id", "proxy_role_name"]
 
 def do_discover(config):
     '''

--- a/tap_dynamodb/__init__.py
+++ b/tap_dynamodb/__init__.py
@@ -6,13 +6,13 @@ from terminaltables import AsciiTable
 import singer
 from singer import metadata
 from tap_dynamodb.discover import discover_streams
-from tap_dynamodb.dynamodb import setup_aws_client
+from tap_dynamodb.dynamodb import setup_aws_client, setup_aws_client_with_proxy
 from tap_dynamodb.sync import sync_stream
 
 
 LOGGER = singer.get_logger()
 
-REQUIRED_CONFIG_KEYS = ["account_id", "external_id", "role_name", "region_name", "proxy_account_id", "proxy_external_id", "proxy_role_name"]
+REQUIRED_CONFIG_KEYS = ["account_id", "external_id", "role_name", "region_name"]
 
 def do_discover(config):
     '''
@@ -97,7 +97,13 @@ def main():
 
     # TODO Is this the right way to do this? It seems bad
     if not config.get('use_local_dynamo'):
-        setup_aws_client(config)
+        # Check if 'proxy_account_id' and 'proxy_role_name' are present in config
+        if config.get('proxy_account_id') and config.get('proxy_role_name'):
+            # If both are present, call setup_aws_client_with_proxy
+            setup_aws_client_with_proxy(config)
+        else:
+            # Otherwise, call setup_aws_client
+            setup_aws_client(config)
 
     if args.discover:
         do_discover(args.config)

--- a/tap_dynamodb/dynamodb.py
+++ b/tap_dynamodb/dynamodb.py
@@ -48,7 +48,7 @@ class AssumeRoleProvider():
         )
 
 
-@retry_pattern
+@retry_pattern()
 def setup_aws_client(config):
     proxy_role_arn = "arn:aws:iam::{}:role/{}".format(config['proxy_account_id'].replace('-', ''),config['proxy_role_name'])
     cust_role_arn = "arn:aws:iam::{}:role/{}".format(config['account_id'].replace('-', ''),config['role_name'])

--- a/tap_dynamodb/dynamodb.py
+++ b/tap_dynamodb/dynamodb.py
@@ -50,6 +50,37 @@ class AssumeRoleProvider():
 
 @retry_pattern()
 def setup_aws_client(config):
+    """
+    Setup the aws session for making the API calls
+    """
+    role_arn = "arn:aws:iam::{}:role/{}".format(config['account_id'].replace('-', ''),
+                                                config['role_name'])
+
+    session = Session()
+    fetcher = AssumeRoleCredentialFetcher(
+        session.create_client,
+        session.get_credentials(),
+        role_arn,
+        extra_args={
+            'DurationSeconds': 3600,
+            'RoleSessionName': 'TapDynamodDB',
+            'ExternalId': config['external_id']
+        },
+        cache=JSONFileCache()
+    )
+
+    refreshable_session = Session()
+    refreshable_session.register_component(
+        'credential_provider',
+        CredentialResolver([AssumeRoleProvider(fetcher)])
+    )
+
+    LOGGER.info("Attempting to assume_role on RoleArn: %s", role_arn)
+    boto3.setup_default_session(botocore_session=refreshable_session)
+
+
+@retry_pattern()
+def setup_aws_client_with_proxy(config):
     proxy_role_arn = "arn:aws:iam::{}:role/{}".format(config['proxy_account_id'].replace('-', ''),config['proxy_role_name'])
     cust_role_arn = "arn:aws:iam::{}:role/{}".format(config['account_id'].replace('-', ''),config['role_name'])
 
@@ -61,8 +92,7 @@ def setup_aws_client(config):
         role_arn=proxy_role_arn,
         extra_args={
             'DurationSeconds': 3600,
-            'RoleSessionName': 'ProxySession',
-            'ExternalId': config['proxy_external_id']
+            'RoleSessionName': 'ProxySession'
         },
         cache=JSONFileCache()
     )
@@ -82,18 +112,11 @@ def setup_aws_client(config):
         role_arn=cust_role_arn,
         extra_args={
             'DurationSeconds': 3600,
-            'RoleSessionName': 'CustSession',
+            'RoleSessionName': 'TapDynamodDBCustSession',
             'ExternalId': config['external_id']
         },
         cache=JSONFileCache()
     )
-
-    # # Refreshable credentials for Account Customer
-    # refreshable_credentials_c = RefreshableCredentials.create_from_metadata(
-    #     metadata=fetcher_cust.fetch_credentials(),
-    #     refresh_using=fetcher_cust.fetch_credentials,
-    #     method="sts-assume-role"
-    # )
 
     # Set up refreshable session for Customer Account
     refreshable_session_cust = Session()


### PR DESCRIPTION
### Overview

This PR introduces functionality to establish a **chained AWS session** for multi-account role assumption, allowing the system to:
1. Assume a role in a `proxy account` and use the resulting credentials.
2. Use the proxy session to assume a secondary role in a `customer account`.
3. Automatically refresh both sessions upon expiration using `RefreshableCredentials` to maintain seamless, uninterrupted access.

### Context

Due to the requirement to perform operations in a `customer account` by first assuming a role in an intermediate (proxy) account, this chained session approach enables:
- **Session Reuse**: Enables reusing a single session across AWS services.
- **Automatic Refreshing**: Ensures that both sessions are refreshed as needed, avoiding disruptions during operations.

### Implementation Details

1. **Primary Role Assumption (Proxy Account)**:
   - Utilizes `AssumeRoleCredentialFetcher` to assume a role in `Proxy`.
   - `RefreshableCredentials` is used to enable automatic refreshing on expiration.
   - This session is cached to avoid redundant calls and improve performance.

2. **Chained Role Assumption (Customer Account)**:
   - Leverages the proxy account session to assume a role in `Customer`.
   - A second `AssumeRoleCredentialFetcher` is set up with `RefreshableCredentials` to automatically refresh upon expiry.

3. **Default Session Setup for boto3**:
   - Configures `boto3` to use this chained session, so all AWS API calls automatically utilize the assumed roles without additional configuration.
   - Logs the current session expiration timestamp to verify that refreshing occurs as expected.

### Example Usage

The setup function initializes the chained session, and subsequent boto3 clients can be created without additional steps. Here’s a usage example:

```python
config = {
    'proxy_account_id': '123456789012',
    'proxy_role_name': 'ProxyRole',
    'account_id': '987654321098',
    'role_name': 'CustomerRole',
    'external_id': 'CustomerExternalID',
    'region': 'us-east-1'
}

setup_aws_client(config)
dynamodb_client = boto3.client('dynamodb')
# Use dynamodb_client for dynamodb operations, with credentials refreshing automatically
