### PR TITLE
remove deprecated terminaltables dependency 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.3.1
+  * Removes deprecated terminaltables dependency [#60](https://github.com/singer-io/tap-dynamodb/pull/60)
+
 ## 1.3.0
   * Updates to run on python 3.11.7 [#57](https://github.com/singer-io/tap-dynamodb/pull/57)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-dynamodb",
-    version="1.3.0",
+    version="1.3.1",
     description="Singer.io tap for extracting data",
     author="Stitch",
     url="http://singer.io",
@@ -12,7 +12,6 @@ setup(
     install_requires=[
         'boto3==1.14.9',
         "singer-python==6.0.0",
-        'terminaltables==3.1.0',
         'backoff==2.2.1',
     ],
     extras_require={

--- a/tap_dynamodb/__init__.py
+++ b/tap_dynamodb/__init__.py
@@ -2,7 +2,6 @@ import json
 import sys
 import time
 
-from terminaltables import AsciiTable
 import singer
 from singer import metadata
 from tap_dynamodb.discover import discover_streams
@@ -57,7 +56,7 @@ def do_sync(config, catalog, state):
         sync_times[stream_name] = time.time() - start_time
         LOGGER.info("%s: Completed sync (%s rows)", stream_name, counts[stream_name])
 
-    LOGGER.info(get_sync_summary(catalog, counts, sync_times))
+    get_sync_summary(catalog, counts, sync_times)
     LOGGER.info('Done syncing.')
 
 def get_sync_summary(catalog, counts, times):
@@ -84,10 +83,10 @@ def get_sync_summary(catalog, counts, times):
                '{:.1f} records/second'.format(stream_count/stream_time)]
         rows.append(row)
 
-    data = headers + rows
-    table = AsciiTable(data, title='Sync Summary')
-
-    return '\n\n' + table.table
+    LOGGER.info("\n**** Sync Summary:")
+    LOGGER.info(next(iter(headers), None))
+    for row in rows:
+        LOGGER.info(row)
 
 
 @singer.utils.handle_top_exception(LOGGER)


### PR DESCRIPTION
# Description of change
removes deprecated terminaltables dependency. sync summary is replaced with plain logging.


# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
